### PR TITLE
테스트를 위한 random api 추가

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,12 +1,94 @@
 from typing import Optional
 from fastapi import FastAPI, Response
 from httpx import AsyncClient
+import uvicorn
 
-from utils import create_solved_dict, boj_rating_to_lv, get_starting_day, get_tomorrow
+from utils import create_solved_dict, boj_rating_to_lv, get_starting_day, get_tomorrow, get_tier_name
+from randoms import random_user, random_timestamp
 import mapping
 
 
 app = FastAPI()
+
+def make_heatmap_svg(handle: str, tier: str, solved_dict: dict, color_theme: dict):
+  tier_name = tier.split(' ')[0]
+  solved_max = solved_dict['solved_max'] if 'solved_max' in solved_dict else 0
+
+  svg = """
+  <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="350" height="170" viewBox="0 0 350 170">
+      <style type="text/css">
+          <![CDATA[
+              @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=block');
+              @keyframes fadeIn {{
+                  0% {{ opacity: 0; }}
+                  40% {{ opacity: 0; }}
+                  100% {{ opacity: 1; }}
+              }}
+              .zandi {{
+                  opacity: 0;
+                  animation: fadeIn 0.5s ease-in-out forwards;
+              }}
+              #handle {{
+                  opacity: 0;
+                  animation: fadeIn 0.5s ease-in-out forwards;
+              }}
+              #tier {{
+                  opacity: 0;
+                  animation: fadeIn 0.5s ease-in-out forwards;
+              }}
+          ]]>
+      </style>
+      <defs>
+          <clipPath id="clip-Gold_-_1">
+          <rect width="350" height="170"/>
+          </clipPath>
+      </defs>
+      <g id="zandies">
+          <rect id="background" width="349" height="169" rx="14" fill="{bgcolor}" style="stroke-width:0.5; stroke:{border};"/>
+          <text id="handle" transform="translate(23 32)" fill="{color}" font-size="14" font-family="NotoSansKR-Black, Noto Sans KR" font-weight="800" style="animation-delay:100ms">{handle}</text>
+          <text id="tier" transform="translate(327 32)" fill="{color}" font-size="12" font-family="NotoSansKR-Black, Noto Sans KR" font-weight="800" text-anchor="end" style="animation-delay:300ms">{tier}</text>
+  """.format(
+    handle=handle,
+    tier=tier,
+    color=color_theme[tier_name][4],
+    border=color_theme['border'],
+    bgcolor=color_theme['background']
+  )
+
+  idx = 0
+  today, now_in_loop = get_starting_day()
+
+  while True:
+      if not solved_dict.get(now_in_loop):
+          color = color_theme[tier_name][0]
+      elif (solved_dict[now_in_loop] / solved_max) > 0.667:
+          color = color_theme[tier_name][3]
+      elif (solved_dict[now_in_loop] / solved_max) > 0.334:
+          color = color_theme[tier_name][2]
+      else:
+          color = color_theme[tier_name][1]
+      
+      nemo = '\n<rect class="zandi"\
+              width="15" height="15" rx="4"\
+              transform="translate({x} {y})" \
+              fill="{color}"\
+              style="animation-delay:{delay}ms"/>\
+              '.format(x=23 + (idx // 7) * 17,
+                        y=44 + (idx % 7) * 16,
+                      color=color,
+                      delay=500 + (idx % 7) * 50 + idx * 4)
+      svg += nemo
+      idx += 1
+
+      if now_in_loop == today:
+          break
+      now_in_loop = get_tomorrow(now_in_loop)
+  
+  svg += """
+      </g>
+  </svg>
+  """
+  return svg
 
 @app.get("/api")
 async def generate_bedge(handle: str, theme: Optional[str] = "warm"):
@@ -14,7 +96,6 @@ async def generate_bedge(handle: str, theme: Optional[str] = "warm"):
     user_info_url = api + '/show?handle=' + handle
     timestamp_url = api + '/history?handle=' + handle + '&topic=solvedCount'
     solved_dict = {}
-    solved_max = 0
     # 테마 색상표 (기본값: WARM)
     theme = theme if theme.upper() in mapping.THEMES else 'warm'
     color_theme = mapping.THEMES[theme.upper()]
@@ -27,92 +108,38 @@ async def generate_bedge(handle: str, theme: Optional[str] = "warm"):
         user_info = user_info.json()
         timestamp = timestamp.json()
         
+        print(timestamp)
         solved_dict = create_solved_dict(timestamp)
-        solved_max = solved_dict['solved_max']
         
         rating = user_info['rating']
         tier = mapping.TIERS[boj_rating_to_lv(rating)]
     else:
         user_info = {'handle': handle, 'rating': 0, 'solved': 0}
         tier = 'Unknown'
-    tier_name = tier.split(' ')[0]
     
-    svg = """
-    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="350" height="170" viewBox="0 0 350 170">
-        <style type="text/css">
-            <![CDATA[
-                @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=block');
-                @keyframes fadeIn {{
-                    0% {{ opacity: 0; }}
-                    40% {{ opacity: 0; }}
-                    100% {{ opacity: 1; }}
-                }}
-                .zandi {{
-                    opacity: 0;
-                    animation: fadeIn 0.5s ease-in-out forwards;
-                }}
-                #handle {{
-                    opacity: 0;
-                    animation: fadeIn 0.5s ease-in-out forwards;
-                }}
-                #tier {{
-                    opacity: 0;
-                    animation: fadeIn 0.5s ease-in-out forwards;
-                }}
-            ]]>
-        </style>
-        <defs>
-            <clipPath id="clip-Gold_-_1">
-            <rect width="350" height="170"/>
-            </clipPath>
-        </defs>
-        <g id="zandies">
-            <rect id="background" width="349" height="169" rx="14" fill="{bgcolor}" style="stroke-width:0.5; stroke:{border};"/>
-            <text id="handle" transform="translate(23 32)" fill="{color}" font-size="14" font-family="NotoSansKR-Black, Noto Sans KR" font-weight="800" style="animation-delay:100ms">{handle}</text>
-            <text id="tier" transform="translate(327 32)" fill="{color}" font-size="12" font-family="NotoSansKR-Black, Noto Sans KR" font-weight="800" text-anchor="end" style="animation-delay:300ms">{tier}</text>
-    """.format(
-      handle=handle,
-      tier=tier,
-      color=color_theme[tier_name][4],
-      border=color_theme['border'],
-      bgcolor=color_theme['background']
-    )
-
-    idx = 0
-    today, now_in_loop = get_starting_day()
-
-    while True:
-        if not solved_dict.get(now_in_loop):
-            color = color_theme[tier_name][0]
-        elif (solved_dict[now_in_loop] / solved_max) > 0.667:
-            color = color_theme[tier_name][3]
-        elif (solved_dict[now_in_loop] / solved_max) > 0.334:
-            color = color_theme[tier_name][2]
-        else:
-            color = color_theme[tier_name][1]
-        
-        nemo = '\n<rect class="zandi"\
-                width="15" height="15" rx="4"\
-                transform="translate({x} {y})" \
-                fill="{color}"\
-                style="animation-delay:{delay}ms"/>\
-                '.format(x=23 + (idx // 7) * 17,
-                         y=44 + (idx % 7) * 16,
-                        color=color,
-                        delay=500 + (idx % 7) * 50 + idx * 4)
-        svg += nemo
-        idx += 1
-
-        if now_in_loop == today:
-            break
-        now_in_loop = get_tomorrow(now_in_loop)
-    
-    svg += """
-        </g>
-    </svg>
-    """
+    svg = make_heatmap_svg(handle, tier, solved_dict, color_theme)
     
     response = Response(content=svg, media_type='image/svg+xml')
     response.headers['Cache-Control'] = 'no-cache'
     
     return response
+
+
+@app.get("/api/random")
+async def generate_random_badge(
+  tier: Optional[str] = None,
+  theme: Optional[str] = "warm"):
+  user = random_user(tier)
+  handle = user['handle']
+  solved_dict = create_solved_dict(random_timestamp())
+  theme = theme if theme.upper() in mapping.THEMES else 'warm'
+  color_theme = mapping.THEMES[theme.upper()]
+
+  svg = make_heatmap_svg(handle, get_tier_name(user['tier']), solved_dict, color_theme)
+
+  response = Response(content=svg, media_type='image/svg+xml')
+  response.headers['Cache-Control'] = 'no-cache'
+
+  return response
+
+uvicorn.run(app, host="0.0.0.0", port="8080")

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 from typing import Optional
 from fastapi import FastAPI, Response
 from httpx import AsyncClient
-import uvicorn
 
 from utils import create_solved_dict, boj_rating_to_lv, get_starting_day, get_tomorrow, get_tier_name
 from randoms import random_user, random_timestamp
@@ -141,5 +140,3 @@ async def generate_random_badge(
   response.headers['Cache-Control'] = 'no-cache'
 
   return response
-
-uvicorn.run(app, host="0.0.0.0", port="8080")

--- a/main.py
+++ b/main.py
@@ -15,7 +15,9 @@ async def generate_bedge(handle: str, theme: Optional[str] = "warm"):
     timestamp_url = api + '/history?handle=' + handle + '&topic=solvedCount'
     solved_dict = {}
     solved_max = 0
-    color_theme = mapping.COLOR_COLD if theme == "cold" else mapping.COLOR_WARM
+    # 테마 색상표 (기본값: WARM)
+    theme = theme if theme.upper() in mapping.THEMES else 'warm'
+    color_theme = mapping.THEMES[theme.upper()]
     
     async with AsyncClient() as client:
         user_info = await client.get(user_info_url)
@@ -65,10 +67,16 @@ async def generate_bedge(handle: str, theme: Optional[str] = "warm"):
             </clipPath>
         </defs>
         <g id="zandies">
-            <rect id="background" width="349" height="169" rx="14" fill="#fdfdfd" style="stroke-width:0.5; stroke:#bfbfbf;"/>
+            <rect id="background" width="349" height="169" rx="14" fill="{bgcolor}" style="stroke-width:0.5; stroke:{border};"/>
             <text id="handle" transform="translate(23 32)" fill="{color}" font-size="14" font-family="NotoSansKR-Black, Noto Sans KR" font-weight="800" style="animation-delay:100ms">{handle}</text>
             <text id="tier" transform="translate(327 32)" fill="{color}" font-size="12" font-family="NotoSansKR-Black, Noto Sans KR" font-weight="800" text-anchor="end" style="animation-delay:300ms">{tier}</text>
-    """.format(handle=handle, tier=tier, color=color_theme[tier_name][4])
+    """.format(
+      handle=handle,
+      tier=tier,
+      color=color_theme[tier_name][4],
+      border=color_theme['border'],
+      bgcolor=color_theme['background']
+    )
 
     idx = 0
     today, now_in_loop = get_starting_day()

--- a/mapping.py
+++ b/mapping.py
@@ -9,7 +9,11 @@ TIERS = (
     "Master"
 )
 
-COLOR_WARM = {
+THEMES = {
+  # THEME: {TIER: [color1, color2, color3, color4, text-color], ...}
+  'WARM': {
+    'border': '#bfbfbf',
+    'background': '#fdfdfd',
     'Unknown': ['#AAAAAA', '#666666', '#000000', '#000000', '#000000'],
     'Unrated': ['#666666', '#2D2D2D', '#040202', '#040202', '#040202'],
     'Bronze': ['#F1F0F5', '#D0BCB0', '#B47F4E', '#522F15', '#A25B36'],
@@ -19,9 +23,10 @@ COLOR_WARM = {
     'Diamond': ['#F1F0F5', '#D5E3FE', '#8EB9FF', '#384EC7', '#3F8EEA'],
     'Ruby': ['#F5F3F0', '#FCC6B8', '#FC849C', '#D93841', '#E15C64'],
     'Master': ['#F3F0F5', '#D6F7FD', '#E1C3FF', '#FC6297', '#CB7CEF'],
-}
-
-COLOR_COLD = {
+  },
+  'COLD': {
+    'border': '#bfbfbf',
+    'background': '#fdfdfd',
     'Unknown': ['#AAAAAA', '#666666', '#000000', '#000000', '#000000'],
     'Unrated': ['#666666', '#2D2D2D', '#040202', '#040202', '#040202'],
     'Bronze': ['#F1F0F5', '#C6B7AE', '#A3805E', '#5D432F', '#A25B36'],
@@ -31,6 +36,20 @@ COLOR_COLD = {
     'Diamond': ['#F1F0F5', '#B4F8F8', '#4AC0F5', '#0065CB', '#1AC0F2'],
     'Ruby': ['#F5F3F0', '#FCDAE4', '#F793B2', '#E51062', '#DB306B'],
     'Master': ['#F3F0F5', '#CCFFFD', '#D5CBFF', '#FC62B5', '#CB7CEF'],
+  },
+  'DARK': {
+    'border': '#5c5c5c',
+    'background': '#3f3f3f',
+    'Unknown': ['#2f2f2f', '#2f2f2f', '#2f2f2f', '#2f2f2f', '#afafaf'],
+    'Unrated': ['#3a3a3a', '#2f2f2f', '#1f1f1f', '#0f0f0f', '#dddddd'],
+    'Bronze': ['#48423c', '#5e4d3c', '#a16b36', '#d57618', '#bb7027'],
+    'Silver': ['#494b4c', '#6e6f72', '#969899', '#ccd1d3', '#94989b'],
+    'Gold': ['#584c3d', '#706c57', '#978046', '#df9239', '#FDC456'],
+    'Platinum': ['#3a5d52', '#358369', '#2fa57e', '#27e2a4', '#39E09D'],
+    'Diamond': ['#515055', '#4d6683', '#5489a3', '#57bcec', '#1AC0F2'],
+    'Ruby': ['#64464e', '#925a69', '#c96684', '#e74778', '#f5457b'],
+    'Master': ['#4e465b', '#715679', '#5c9caa', '#FF7CA8', '#CB7CEF'],
+  }
 }
 
 TIER_RATES = (

--- a/randoms.py
+++ b/randoms.py
@@ -1,0 +1,63 @@
+import random
+from datetime import datetime, timedelta
+from string import ascii_lowercase
+from typing import Optional
+
+from utils import get_tier_id
+
+# tier: None=random, 0=unknown, 1~5: bronze, 6~10: silver, ...
+def random_user(tier: Optional[str] = None):
+  if not tier:
+    tier = '{tier} {lv}'.format(
+      tier=random.choice(['bronze', 'silver', 'gold', 'platinum', 'diamond', 'ruby', 'master']),
+      lv=random.randint(1, 5)
+    )
+  elif len(tier.split(' ')) == 1:
+    tier = '{tier} {lv}'.format(tier=tier, lv=random.randint(1, 5))
+  print('tier', tier)
+  hash = ''.join(random.choice(ascii_lowercase) for i in range(5))
+  handle = 'random-{}'.format(hash)
+  result = {
+    'handle': handle,
+    'bio': '',
+    'organizations': [],
+    'badge': None,
+    'background': {
+      'backgroundId': 'abstract_001_light',
+      'backgroundImageUrl': 'https://static.solved.ac/profile_bg/abstract_001/abstract_001_light.png',
+      'unlockedUserCount': 0,
+      'displayName': '아이콘',
+      'displayDescription': 'solved.ac 아이콘'
+    },
+    'profileImageUrl': None,
+    'solvedCount': 69,
+    'voteCount': 0,
+    'class': 1,
+    'classDecoration': 'none',
+    'tier': get_tier_id(tier),
+    'rating': 198,
+    'ratingByProblemsSum': 122,
+    'ratingByClass': 25,
+    'ratingBySolvedCount': 51,
+    'ratingByVoteCount': 0,
+    'exp': 47544,
+    'rivalCount': 0,
+    'reverseRivalCount': 0,
+    'maxStreak': 3,
+    'rank': 29946
+  }
+  return result
+
+
+# generate random timestamp
+def random_timestamp():
+  current = datetime.now()
+  result = []
+  count = 7 * 18   # 18 weeks
+  for i in range(count):
+    result.append({
+      'timestamp': current.isoformat(),
+      'value': count - i
+    })
+    current -= timedelta(hours=random.randint(0, 48))
+  return result

--- a/utils.py
+++ b/utils.py
@@ -65,3 +65,26 @@ def get_tomorrow(timestamp):
     tomorrow = timedata + datetime.timedelta(days=1)
 
     return tomorrow.strftime('%Y-%m-%d')
+
+
+# solved.ac에서 사용하는 티어 id (0:Unrated, 1~5:Bronze, ..., 31:Master)
+def get_tier_name(id: int):
+  if id == 0: return 'Unrated'
+  lut = ['Bronze', 'Silver', 'Gold', 'Platinum', 'Diamond', 'Ruby', 'Master']
+  tier = lut[(id - 1) // 5]
+  lv = ((id - 1) % 5) + 1
+  if tier == 'Master': return 'Master'
+  return '{tier} {lv}'.format(tier=tier, lv=lv)
+
+
+# 티어명을 solved.ac에서 사용하는 티어 id로 변환 ('Bronze 4' => 2)
+def get_tier_id(name: str):
+  name = name.lower()
+  arr = name.split(' ') + [None] # padding when level is empty
+  tier = arr[0]
+  lv = int(arr[1]) if arr[1] else 0
+  lut = ['bronze', 'silver', 'gold', 'platinum', 'diamond', 'ruby', 'master']
+  if tier in lut:
+    if tier == 'master': return 31
+    return lut.index(tier) * 5 + lv
+  return 0 # unrated


### PR DESCRIPTION
테마 추가하면서 티어별로 색깔을 확인하기가 어려워서 random 하게 색깔을 찍어주도록 만들어봤습니다.

기존의 [` create_solved_dict(json)`](https://github.com/mazassumnida/mazandi/blob/cbe96ee44e6a7da2598e89396b9fa78141f87d74/utils.py#L19) 함수가 호환될 수 있게 solved.ac의 json response를 random하게 생성하는 방식으로 구현했습니다.

아래 request의 결과:

```
/api/random?theme=dark&tier=diamond
```
![](https://gist.githubusercontent.com/joonas-yoon/1d4c0b082d6edf0a7f1964a2cb4b1173/raw/e9f52d2a63c1310cac0cc213f7f3162d2ccae8c9/random.svg)

**Parameters**
- theme : (Optional) 생략 시 기본값 (warm)
- tier: (Optional) 생략 시 모든 티어에서 랜덤
- - 티어명 뒤의 숫자 생략 시 (`rudy` 등) 랜덤하게 1~5가 붙음 (`Unrated`, `Master` 제외)

```
/api/random?theme=warm&tier=diamond
```

```
/api/random?theme=cold&tier=diamond%204
```

```
/api/random?theme=cold
```

```
/api/random?tier=diamond
```

```
/api/random
```