### PR TITLE
Match streak color breakpoint specs to solved.ac

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,7 +59,7 @@ def make_heatmap_svg(handle: str, tier: str, solved_dict: dict, color_theme: dic
   while True:
       # solved.ac streak specs:
       # n := clamp (solved_max) to [4, 50]
-      # [1, 0.1n), [0.1n, 0.3n), [0.3n, 0.6n), [0.6n, 1.0n]
+      # [0, 0], [1, 0.1n), [0.1n, 0.3n), [0.3n, 0.6n), [0.6n, 1.0n] -- all values are rounded up
       if not solved_dict.get(now_in_loop):
           color = color_theme[tier_name][0]
       elif (solved_dict[now_in_loop]) >= ((solved_max * 6 + 9) // 10):

--- a/main.py
+++ b/main.py
@@ -6,7 +6,6 @@ from utils import create_solved_dict, boj_rating_to_lv, get_starting_day, get_to
 from randoms import random_user, random_timestamp
 import mapping
 
-
 app = FastAPI()
 
 def make_heatmap_svg(handle: str, tier: str, solved_dict: dict, color_theme: dict):
@@ -58,11 +57,16 @@ def make_heatmap_svg(handle: str, tier: str, solved_dict: dict, color_theme: dic
   today, now_in_loop = get_starting_day()
 
   while True:
+      # solved.ac streak specs:
+      # n := clamp (solved_max) to [4, 50]
+      # [1, 0.1n), [0.1n, 0.3n), [0.3n, 0.6n), [0.6n, 1.0n]
       if not solved_dict.get(now_in_loop):
           color = color_theme[tier_name][0]
-      elif (solved_dict[now_in_loop] / solved_max) > 0.667:
+      elif (solved_dict[now_in_loop]) >= ((solved_max * 6 + 9) // 10):
+          color = color_theme[tier_name][4]
+      elif (solved_dict[now_in_loop]) >= ((solved_max * 3 + 9) // 10):
           color = color_theme[tier_name][3]
-      elif (solved_dict[now_in_loop] / solved_max) > 0.334:
+      elif (solved_dict[now_in_loop]) >= ((solved_max * 1 + 9) // 10):
           color = color_theme[tier_name][2]
       else:
           color = color_theme[tier_name][1]

--- a/utils.py
+++ b/utils.py
@@ -46,6 +46,8 @@ def create_solved_dict(json):
             solved_dict[timestamp] += 1
             solved_dict['solved_max'] = max(solved_dict['solved_max'], solved_dict[timestamp])
             
+    solved_dict['solved_max'] = min(solved_dict['solved_max'], 50)
+
     return solved_dict
 
 


### PR DESCRIPTION
This pull request fixes the color breakpoints to match that of solved.ac.

## Changes

The breakpoint algorithm is implemented as following:

* Let $n$ be the max number of solves for one day, clamped to $\left[4, 50\right]$. i. e., $\max \left\\{ \min \left\\{ 50, \texttt{solved\\_max} \right\\}, 4 \right\\}$.
* Then the breakpoints are:

| Color | Range |
| -- | -- |
| Gray | $\left[0\right]$ |
| Accent 1 | $\displaystyle \left[1, \left\lceil\frac{1}{10}n\right\rceil \right)$ |
| Accent 2 | $\displaystyle \left[\left\lceil\frac{1}{10}n\right\rceil, \left\lceil\frac{3}{10}n\right\rceil \right)$ |
| Accent 3 | $\displaystyle \left[\left\lceil\frac{3}{10}n\right\rceil, \left\lceil\frac{6}{10}n\right\rceil \right)$ |
| Accent 4 | $\displaystyle \left[\left\lceil\frac{6}{10}n\right\rceil, \infty \right)$ |

[main.py](https://github.com/mazassumnida/mazandi/blob/c2dd29de5efedb715bd0c5fb04a3a9297497149c/main.py) is modified to use a 5-color scheme instead of the existing 4-color scheme. Though [mapping.py](https://github.com/mazassumnida/mazandi/blob/main/mapping.py) already has five colors defined, I recommend reviewing the code carefully before merging.

Thanks for building such a great project!